### PR TITLE
Makefile: add template-haskell to INSTALL_DEPS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ HADDOCKFLAGS = \
   -i $(shell find /usr/share/doc/ghc/html/libraries -name template-haskell.haddock | tail -1) \
   $(shell grep -q "Arch Linux" /etc/lsb-release && echo --optghc=-dynamic) \
   | grep -v "^Warning: Couldn't find .haddock for export [A-Z]$$"
-INSTALL_DEPS = leancheck express speculate
+INSTALL_DEPS = leancheck express speculate template-haskell
 
 EG = \
   eg/arith \


### PR DESCRIPTION
to hopefully fix the following CI build error:

	$ make
	ghc -isrc:test -O2 -v0  mk/Toplibs.hs && touch mk/Toplibs.o
	src/Conjure/Conjurable/Derive.hs:27:1: error:
		Could not load module ‘Language.Haskell.TH.Lib’
		It is a member of the hidden package ‘template-haskell-2.19.0.0’.
		You can run ‘:set -package template-haskell’ to expose it.